### PR TITLE
Use the candidates names instead of IDs

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -129,16 +129,16 @@
         .table .thead-light th, .table td {
             border-color: #211d19;
         }
-        .cortez_masto-c {
+        .CatherineCortezMasto {
             background-color: #05456F;
         }
-        .laxalt-a {
+        .AdamLaxalt {
             background-color: #6E192A;
         }
-        .kelly-m {
+        .MarkKelly {
             background-color: #05456F;
         }
-        .masters-b {
+        .MastersBlake {
             background-color: #6E192A;
         }
     }

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -27,7 +27,7 @@ STATE_INDEXES = [2, 19]
 
 CACHE_DIR = '_cache'
 # Bump this with any changes to `fetch_all_records`
-CACHE_VERSION = 2
+CACHE_VERSION = 3
 
 def git_commits_for(path):
     return subprocess.check_output(['git', 'log', "--format=%H", path]).strip().decode().splitlines()
@@ -131,7 +131,7 @@ IterationSummary = collections.namedtuple(
     [
         'timestamp',
         'leading_candidate_name',
-        'trailing_candidate_name',
+        'trailing_  candidate_name',
         'leading_candidate_votes',
         'trailing_candidate_votes',
         'vote_differential',

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -64,13 +64,23 @@ def fetch_all_records():
         for index in STATE_INDEXES:
             race = json['races'][index]
 
+            candidate_id_to_name = {
+                candidate_id: " ".join(name for name in [
+                    metadata['first_name'], metadata['last_name'],
+                ] if name)
+                for candidate_id, metadata in race['candidate_metadata'].items()
+            }
+
             tot_exp_vote = race['top_reporting_unit']['total_expected_vote']
             record = InputRecord(
                 timestamp,
                 race['top_reporting_unit']['name'],
                 race['top_reporting_unit']['state_postal'],
                 1,
-                race['top_reporting_unit']['candidates'].as_list(),
+                [
+                    {'candidate_name': candidate_id_to_name[candidate['nyt_id']], **candidate}
+                    for candidate in race['top_reporting_unit']['candidates'].as_list()
+                ],
                 race['top_reporting_unit']['total_votes'],
                 tot_exp_vote,
                 race['top_reporting_unit']['precincts_total'],
@@ -250,7 +260,7 @@ def html_summary(state_slug: str, summary: IterationSummary, always_visible: boo
     html = f'''
         <tr id="{state_slug}-{summary.timestamp.isoformat()}"{always_visible_attribute}>
             <td class="timestamp">{summary.timestamp.strftime('%Y-%m-%d %H:%M:%S')} UTC</td>
-            <td class="{summary.leading_candidate_name}">{summary.leading_candidate_name}</td>
+            <td class="{summary.leading_candidate_name.replace(" ", "")}">{summary.leading_candidate_name}</td>
             <td class="numeric">{summary.vote_differential:,}</td>
             <td class="numeric">{shown_votes_remaining}</td>
             <td {counties_tooltip_attributes}>{summary.new_votes_formatted}</td>
@@ -313,8 +323,8 @@ def json_to_summary(
     # Retrieve relevant data from the state’s JSON blob
     candidate1 = row.candidates[0] # Leading candidate
     candidate2 = row.candidates[1] # Trailing candidate
-    candidate1_name = candidate1['nyt_id']
-    candidate2_name = candidate2['nyt_id']
+    candidate1_name = candidate1['candidate_name']
+    candidate2_name = candidate2['candidate_name']
     candidate1_votes = candidate1['votes']['total']
     candidate2_votes = candidate2['votes']['total']
     candidate1_key = candidate1['nyt_id']

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -131,7 +131,7 @@ IterationSummary = collections.namedtuple(
     [
         'timestamp',
         'leading_candidate_name',
-        'trailing_  candidate_name',
+        'trailing_candidate_name',
         'leading_candidate_votes',
         'trailing_candidate_votes',
         'vote_differential',


### PR DESCRIPTION
###### Motivation
Wanted to see their names instead of IDs

###### Changes
Fixes the "candidate name" column to be their name instead of IDs :D

<img width="307" alt="image" src="https://user-images.githubusercontent.com/681004/201461986-c0fd47ef-41b3-43f0-b899-4e6dfaa1b375.png">


- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
